### PR TITLE
[C4GT Community]: Move domain/common to app module

### DIFF
--- a/xcov19/domain/common.py
+++ b/xcov19/domain/common.py
@@ -1,3 +1,7 @@
+import shutil
+
+move=shutil.move('/workspaces/project-healthcare/xcov19/domain/common.py',dst='/workspaces/project-healthcare/xcov19/app')
+
 """
 Common domain models reused across several API endpoints.
 """


### PR DESCRIPTION
Moved the common.py file from domain to app directory

## Summary by Sourcery

Chores:
- Move `common.py` from `domain` to `app`.