### PR TITLE
[C4GT Community]: Replace FromOriginMatchHeader secret to locally set environment variable

### DIFF
--- a/xcov19/app/settings.py
+++ b/xcov19/app/settings.py
@@ -1,3 +1,9 @@
+from dotenv import find_dotenv,load_dotenv
+import os
+
+fetch_dotenv=find_dotenv()
+load_dotenv(fetch_dotenv)
+
 """
 Application settings handled using Pydantic Settings management.
 
@@ -49,4 +55,4 @@ def load_settings() -> Settings:
 
 class FromOriginMatchHeader(FromHeader[str]):
     name = "X-Origin-Match-Header"
-    secret = "secret"
+    secret = os.getenv('string')


### PR DESCRIPTION
Replace FromOriginMatchHeader secret to locally set environment variable

## Summary by Sourcery

Replace the `FromOriginMatchHeader` secret with a locally set environment variable.

New Features:
- Use an environment variable to store the secret for the `FromOriginMatchHeader` class.

Enhancements:
- Load environment variables from a .env file.