### PR TITLE
refactor: use env var for FromOriginMatchHeader secret [#57]

### DIFF
--- a/xcov19/app/middleware.py
+++ b/xcov19/app/middleware.py
@@ -1,9 +1,8 @@
 from typing import Callable, Awaitable
-import os
 
 from blacksheep import Application, Request, Response, bad_request
 
-from xcov19.app.settings import FromOriginMatchHeader
+from xcov19.app.settings import FromOriginMatchHeader, ORIGIN_MATCH_SECRET
 
 
 def configure_middleware(app: Application, *middlewares):
@@ -17,13 +16,10 @@ async def origin_header_middleware(
     if request.path.startswith("/docs") or request.path.startswith("/openapi"):
         return await handler(request)
 
-    # Get expected secret from environment
-    expected_secret = os.getenv("FROM_ORIGIN_HEADER_SECRET", "default-dev-secret").encode()
-
-    # Get actual header from request
+    # Use centralized secret value from settings
+    expected_secret = ORIGIN_MATCH_SECRET.encode()
     actual_header = request.headers.get(FromOriginMatchHeader.name.encode())
 
-    # Compare
     if actual_header == (expected_secret,):
         return await handler(request)
     else:

--- a/xcov19/app/middleware.py
+++ b/xcov19/app/middleware.py
@@ -1,4 +1,5 @@
 from typing import Callable, Awaitable
+import os
 
 from blacksheep import Application, Request, Response, bad_request
 
@@ -12,12 +13,18 @@ def configure_middleware(app: Application, *middlewares):
 async def origin_header_middleware(
     request: Request, handler: Callable[[Request], Awaitable[Response]]
 ) -> Response:
-    if not FromOriginMatchHeader.name:
-        raise ValueError("FromOriginMatchHeader name is not set.")
+    # Allow open endpoints without validation
     if request.path.startswith("/docs") or request.path.startswith("/openapi"):
         return await handler(request)
-    match request.headers.get(FromOriginMatchHeader.name.encode()):
-        case (b"secret",):
-            return await handler(request)
-        case _:
-            return bad_request("Invalid origin match header value provided.")
+
+    # Get expected secret from environment
+    expected_secret = os.getenv("FROM_ORIGIN_HEADER_SECRET", "default-dev-secret").encode()
+
+    # Get actual header from request
+    actual_header = request.headers.get(FromOriginMatchHeader.name.encode())
+
+    # Compare
+    if actual_header == (expected_secret,):
+        return await handler(request)
+    else:
+        return bad_request("Invalid origin match header value provided.")

--- a/xcov19/app/settings.py
+++ b/xcov19/app/settings.py
@@ -11,7 +11,7 @@ from typing import Annotated
 from blacksheep import FromHeader
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
+import os
 
 class APIInfo(BaseModel):
     title: str = "xcov19 API"
@@ -49,4 +49,4 @@ def load_settings() -> Settings:
 
 class FromOriginMatchHeader(FromHeader[str]):
     name = "X-Origin-Match-Header"
-    secret = "secret"
+    secret = os.getenv("FROM_ORIGIN_HEADER_SECRET", "default-dev-secret")

--- a/xcov19/app/settings.py
+++ b/xcov19/app/settings.py
@@ -13,6 +13,10 @@ from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 import os
 
+# ✅ Centralized secret fetch (single source of truth)
+ORIGIN_MATCH_SECRET = os.getenv("FROM_ORIGIN_HEADER_SECRET", "default-dev-secret")
+
+
 class APIInfo(BaseModel):
     title: str = "xcov19 API"
     version: str = "0.0.1"
@@ -49,4 +53,3 @@ def load_settings() -> Settings:
 
 class FromOriginMatchHeader(FromHeader[str]):
     name = "X-Origin-Match-Header"
-    secret = os.getenv("FROM_ORIGIN_HEADER_SECRET", "default-dev-secret")


### PR DESCRIPTION
-  **Replaced hardcoded FromOriginMatchHeader secret with env var**
-  **Confirmed functionality with both /diagnose and /geo endpoints**
-  **Smoke tested via Swagger UI**

<img width="1440" alt="Screenshot 2025-05-01 at 1 17 03 AM" src="https://github.com/user-attachments/assets/a7347874-c43d-4038-985b-1c7fedfbe5ee" />
<img width="1440" alt="Screenshot 2025-05-01 at 1 17 16 AM" src="https://github.com/user-attachments/assets/b51a8bb1-0f83-4312-a2bf-4bbeb57b2793" />
<img width="1440" alt="Screenshot 2025-05-01 at 1 17 23 AM" src="https://github.com/user-attachments/assets/7c6921e2-93ce-435f-a6ea-0158a151c1ea" />
<img width="1440" alt="Screenshot 2025-05-01 at 1 17 39 AM" src="https://github.com/user-attachments/assets/d44d3b6a-fefd-4261-a796-d9e1544f3a58" />

## Summary by Sourcery

Refactor the FromOriginMatchHeader secret to use an environment variable instead of a hardcoded value, improving configuration flexibility and security.

Enhancements:
- Replaced hardcoded secret with configurable environment variable
- Updated middleware to dynamically fetch secret from environment

Chores:
- Updated settings and middleware to support environment-based configuration