### PR TITLE
refactor: use env var for FromOriginMatchHeader secret [#57]

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ if [ -f "xcov19.db" ]; then
     rm xcov19.db; 
 fi;
 
-APP_ENV=dev APP_DB_ENGINE_URL="sqlite+aiosqlite:///xcov19.db" poetry run python3 -m xcov19.dev
+APP_API_SECRET=OnlyIKnow APP_ENV=dev APP_DB_ENGINE_URL="sqlite+aiosqlite:///xcov19.db" poetry run python3 -m xcov19.dev

--- a/xcov19/app/middleware.py
+++ b/xcov19/app/middleware.py
@@ -2,7 +2,7 @@ from typing import Callable, Awaitable
 
 from blacksheep import Application, Request, Response, bad_request
 
-from xcov19.app.settings import FromOriginMatchHeader
+from xcov19.app.settings import FromOriginMatchHeader, load_settings
 
 
 def configure_middleware(app: Application, *middlewares):
@@ -12,12 +12,13 @@ def configure_middleware(app: Application, *middlewares):
 async def origin_header_middleware(
     request: Request, handler: Callable[[Request], Awaitable[Response]]
 ) -> Response:
+    api_secret = load_settings().api_secret.encode()
     if not FromOriginMatchHeader.name:
         raise ValueError("FromOriginMatchHeader name is not set.")
     if request.path.startswith("/docs") or request.path.startswith("/openapi"):
         return await handler(request)
     match request.headers.get(FromOriginMatchHeader.name.encode()):
-        case (b"secret",):
+        case x if api_secret in x:
             return await handler(request)
         case _:
             return bad_request("Invalid origin match header value provided.")

--- a/xcov19/app/settings.py
+++ b/xcov19/app/settings.py
@@ -28,6 +28,7 @@ class Site(BaseModel):
 
 class Settings(BaseSettings):
     db_engine_url: Annotated[str, "database connection string"] = Field(default=...)
+    api_secret: Annotated[str, "api_secret"] = Field(default=...)
 
     # to override info:
     # export app_info='{"title": "x", "version": "0.0.2"}'
@@ -49,4 +50,3 @@ def load_settings() -> Settings:
 
 class FromOriginMatchHeader(FromHeader[str]):
     name = "X-Origin-Match-Header"
-    secret = "secret"


### PR DESCRIPTION
# Goals

- [x] Refactor to use locally generated from environment variable
- [x] make run and smoke test to verify APIs don't break after refactor

# Expected Outcome

- [x] No change in API behaviour
- [x] Sending wrong secret in the API call which is different from locally generated secret fails

# Blocker

> Current Test Suite fails on setup with below output ( removed some warnings cluttering the output )

TestClient `post` call is not integrated so fails before asserting the response

```
APP_DB_ENGINE_URL="sqlite+aiosqlite://" APP_API_SECRET=testme pytest
F......                                                                                                  [100%]
=================================================== FAILURES ===================================================
_______________________________ TestGeolocationAPI.test_location_query_endpoint ________________________________

self = <xcov19.tests.test_geolocation_api.TestGeolocationAPI object at 0x107878080>
client = <function test_client.<locals>.start_client at 0x108840fe0>

    async def test_location_query_endpoint(self, client):
        # Prepare the request payload
        location_query = LocationQueryJSON(
            location=GeoLocation(lat=0, lng=0),
            cust_id=AnonymousId(cust_id="test_cust_id"),
            query_id=QueryId(query_id="test_query_id"),
        )
    
        # Send a POST request to the /geo endpoint
        query = location_query.model_dump(round_trip=True)
        binary_data = json.dumps(query).encode("utf-8")
        print("binary data", binary_data, type(binary_data))
>       response: Response = await client.post(
            "/geo",
            content=Content(b"application/json", binary_data),
            # Add the required header
            headers={
                "X-Origin-Match-Header": "secret",
            },
        )
E       AttributeError: 'function' object has no attribute 'post'

xcov19/tests/test_geolocation_api.py:24: AttributeError
--------------------------------------------- Captured stdout call ---------------------------------------------
binary data b'{"location": {"lat": 0.0, "lng": 0.0}, "cust_id": {"cust_id": "test_cust_id"}, "query_id": {"query_id": "test_query_id"}}' <class 'bytes'>

FAILED xcov19/tests/test_geolocation_api.py::TestGeolocationAPI::test_location_query_endpoint - AttributeError: 'function' object has no attribute 'post'
1 failed, 6 passed, 2 warnings in 0.29s
```

# Acceptance Criteria

There is a Pytest e2e Testsuite which tests for the expected outcomes in the following cases:

- [ ] Test asserts true when no change in API behaviour when correct secret is supplied
- [ ] Test asserts failure when sending wrong secret in the API call which is different from locally generated secret fails
- [ ] No mocks are used.

# Observations

- Docker build for **dev** complains on missing `--no-update` option and have to comment the line to make it pass

```
diff --git a/Dockerfile.build b/Dockerfile.build
index 0ecd31b..be02925 100644
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -111,7 +111,7 @@ USER nonroot:nonroot
 # Install project dependencies
 ARG INSTALL_CMD="poetry install --only main --no-root --no-ansi"
 RUN if [ -z "${INSTALL_CMD}" ]; then echo "Unable to start poetry install command" && exit 1; fi
-RUN if [ -f "poetry.lock" ]; then \
- echo "poetry lock exists. updating" && \
- chmod 755 poetry.lock && poetry lock --no-update; fi;
+# RUN if [ -f "poetry.lock" ]; then \
+#  echo "poetry lock exists. updating" && \
+#  chmod 755 poetry.lock && poetry lock --no-update; fi;
 RUN ${INSTALL_CMD}
\ No newline at end of file
```

- Docker build for **test-integration** complains on missing `--no-update` option and have to comment the line to make it pass

```
diff --git a/Dockerfile.test-integration b/Dockerfile.test-integration
index 14ae986..17f1599 100644
--- a/Dockerfile.test-integration
+++ b/Dockerfile.test-integration
@@ -17,10 +17,12 @@ USER nonroot:nonroot
 
 ARG INSTALL_CMD="poetry install --no-root --no-ansi --extras=test"
 RUN if [ -z "${INSTALL_CMD}" ]; then echo "Unable to start poetry install command" && exit 1; fi
-RUN if [ -f "poetry.lock" ]; then echo "poetry lock exists. updating" && poetry lock --no-update; fi;
+# RUN if [ -f "poetry.lock" ]; then echo "poetry lock exists. updating" && poetry lock --no-update; fi;
 RUN ${INSTALL_CMD}
 
 ARG START_CMD="make test-integration"
 ENV START_CMD=${START_CMD}
 RUN if [ -z "${START_CMD}" ]; then echo "Unable to detect a container start command" && exit 1; fi
+
+#CMD ["make", "test-integration"]
 CMD ${START_CMD}
\ No newline at end of file
```

## Summary by Sourcery

Refactor the API secret handling to use an environment variable for origin header matching, improving security and flexibility of the authentication mechanism.

New Features:
- Add API secret as a configurable setting in the application settings

Bug Fixes:
- Fix potential hardcoded secret vulnerability by using dynamic secret loading

Enhancements:
- Modify origin header middleware to dynamically load API secret from environment settings

Chores:
- Update Dockerfiles to remove commented poetry lock commands