### PR TITLE
Fix generics and python compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = true
 
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = ">=3.11,<4.0"
 pydantic = "^2.9.1"
 blacksheep = "^2.0.7"
 Hypercorn = "^0.17.3"
@@ -58,7 +58,7 @@ env = [
 ]
 
 [tool.pyright]
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 useLibraryCodeForTypes = true
 verboseOutput = true
 include = [

--- a/xcov19/domain/models/__init__.py
+++ b/xcov19/domain/models/__init__.py
@@ -1,8 +1,8 @@
-from typing import Tuple
+from typing import Tuple, TypeAlias
 
-type Mobile = str
-type Telephone = str
-type MobileTelephone = Mobile | Telephone
-type longitude = float
-type latitude = float
-type GeoLocation = Tuple[latitude, longitude]
+Mobile: TypeAlias = str
+Telephone: TypeAlias = str
+MobileTelephone: TypeAlias = Mobile | Telephone
+longitude: TypeAlias = float
+latitude: TypeAlias = float
+GeoLocation: TypeAlias = Tuple[latitude, longitude]

--- a/xcov19/domain/models/patient.py
+++ b/xcov19/domain/models/patient.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
+from typing import TypeAlias
 from xcov19.domain.models import GeoLocation
 
-type CustomerId = str
+CustomerId: TypeAlias = str
 
 # domain entities
 

--- a/xcov19/domain/models/provider.py
+++ b/xcov19/domain/models/provider.py
@@ -1,7 +1,7 @@
 import dataclasses
 import enum
 from dataclasses import dataclass
-from typing import Annotated, List
+from typing import Annotated, List, Generic, TypeVar, TypeAlias
 from xcov19.domain.models import MobileTelephone, GeoLocation
 
 
@@ -22,18 +22,21 @@ class FacilityOwnership(enum.StrEnum):
     CHARITY = "charity"
 
 
-type FacilityType = FacilityEstablishment
-type FacilityOwnerType = FacilityOwnership
-type ProviderName = str
-type Specialties = List[str]
-type Qualification = List[str]
-type PracticeExpYears = int | float
-type MoneyType = int | float
+FacilityType: TypeAlias = FacilityEstablishment
+FacilityOwnerType: TypeAlias = FacilityOwnership
+ProviderName: TypeAlias = str
+Specialties: TypeAlias = List[str]
+Qualification: TypeAlias = List[str]
+PracticeExpYears: TypeAlias = int | float
+MoneyType: TypeAlias = int | float
+
+
+T_Mobile = TypeVar("T_Mobile", bound=MobileTelephone)
 
 
 @dataclass
-class Contact[T: MobileTelephone]:
-    value: T
+class Contact(Generic[T_Mobile]):
+    value: T_Mobile
 
     def _valid_prefix(self) -> bool:
         return self.value[0] == "+" or ord("0") <= ord(self.value[0]) <= ord("9")

--- a/xcov19/domain/repository_interface.py
+++ b/xcov19/domain/repository_interface.py
@@ -1,14 +1,14 @@
-from typing import Protocol, TypeVar, List
+from typing import Protocol, TypeVar, List, Generic
 import abc
 
 from xcov19.domain.models.patient import Patient
 from xcov19.domain.models.provider import Provider
 
 PatientT = TypeVar("PatientT", bound=Patient)
-ProviderT = TypeVar("ProviderT", bound=Patient)
+ProviderT = TypeVar("ProviderT", bound=Provider)
 
 
-class IPatientStore[PatientT: Patient](Protocol):
+class IPatientStore(Protocol, Generic[PatientT]):
     @classmethod
     @abc.abstractmethod
     def enqueue_diagnosis_query(cls, patient: PatientT):
@@ -20,7 +20,7 @@ class IPatientStore[PatientT: Patient](Protocol):
         raise NotImplementedError
 
 
-class IProviderRepository[ProviderT: Provider](Protocol):
+class IProviderRepository(Protocol, Generic[ProviderT]):
     @abc.abstractmethod
     def fetch_by_providers(self, **address: dict[str, str]) -> List[ProviderT]:
         raise NotImplementedError

--- a/xcov19/services/geolocation.py
+++ b/xcov19/services/geolocation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TypeVar, Protocol, Callable, List
+from typing import TypeVar, Protocol, Callable, List, Generic
 
 from xcov19.dto import LocationQueryJSON, Address, FacilitiesResult
 from xcov19.utils.mixins import InterfaceProtocolCheckMixin
@@ -12,7 +12,7 @@ T = TypeVar("T", bound=LocationQueryJSON)
 # Application services
 
 
-class LocationQueryServiceInterface[T: LocationQueryJSON](Protocol):
+class LocationQueryServiceInterface(Protocol, Generic[T]):
     """Location aware service for listing faciltiies.
     1. Searches and fetches existing processed results by query_id for a cust_id
     2. Resolves coordinates from a given geolocation.


### PR DESCRIPTION
## Summary
- make project compatible with python 3.11
- replace PEP695 type hints with TypeAlias/generic
- correct provider type bound in repository interface

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847dc7e9f70832cb8fcc67faead8cd4

## Summary by Sourcery

Upgrade Python compatibility, standardize type alias definitions using typing.TypeAlias, refine generic class and Protocol declarations, and correct a generic type bound.

Bug Fixes:
- Fix ProviderT TypeVar bound in IProviderRepository to Provider instead of Patient.

Enhancements:
- Require Python >=3.11,<4.0 and update pyright config accordingly.
- Convert all custom type aliases to use typing.TypeAlias for broader compatibility.
- Refactor generic classes and Protocol interfaces (Contact, IPatientStore, IProviderRepository, LocationQueryServiceInterface) to use typing.Generic.