### PR TITLE
Fix InterfaceProtocolCheckMixin to validate interface method existence and signatures (Fixes #50)

### DIFF
--- a/xcov19/utils/mixins.py
+++ b/xcov19/utils/mixins.py
@@ -38,32 +38,59 @@ def match_signature(
 
 
 class InterfaceProtocolCheckMixin:
-    """Checks for correct signature used by the implementation class.
-
-    Drop in mixin wherever an implementation is subclasses with an
-    interface definition.
-    """
-
     def __init_subclass__(cls, **kwargs):
-        parent_class = inspect.getmro(cls)[1]
-        # raise Exception(inspect.getmembers(cls, predicate=inspect.isfunction))
-        for defined_method in (
-            method_name
-            for method_name, _ in inspect.getmembers(cls, predicate=inspect.ismethod)
-            if not method_name.startswith("__")
-        ):
-            # TODO: Raise if either classes don't have the method declared.
-            cls_method = getattr(parent_class, defined_method)
-            subclass_method = getattr(cls, defined_method)
-            cls_method_params: dict = get_type_hints(cls_method)
-            subclass_method_params: dict = get_type_hints(subclass_method)
-            if len(cls_method_params) != len(subclass_method_params):
-                raise NotImplementedError(f"""Method parameters mismatch:
-                Expected: {cls_method_params.keys()}
-                Got: {subclass_method_params.keys()}
-                """)
-            for cls_signature, subclass_signature in zip(
-                cls_method_params.items(), subclass_method_params.items()
-            ):
-                match_signature(cls_signature, subclass_signature)
         super().__init_subclass__(**kwargs)
+
+        # Identify the interface class (exclude the mixin itself)
+        interfaces = [
+            base for base in cls.__bases__
+            if base is not InterfaceProtocolCheckMixin
+        ]
+
+        # If class does not implement an interface, skip checks
+        if not interfaces:
+            return
+
+        # Usually only one interface
+        interface = interfaces[0]
+
+        # Collect all callable methods in the interface (ignore dunders)
+        interface_methods = {
+            name: func
+            for name, func in interface.__dict__.items()
+            if callable(func) and not name.startswith("__")
+        }
+
+        # Collect all callable methods in the implementation (ignore dunders)
+        implementation_methods = {
+            name: func
+            for name, func in cls.__dict__.items()
+            if callable(func) and not name.startswith("__")
+        }
+
+        # 1. Interface method missing in implementation
+        for name, func in interface_methods.items():
+            if name not in implementation_methods:
+                raise NotImplementedError(
+                    f"Class '{cls.__name__}' must implement method '{name}' "
+                    f"declared in interface '{interface.__name__}'."
+                )
+
+            # Check method signatures
+            sig_interface = inspect.signature(func)
+            sig_impl = inspect.signature(implementation_methods[name])
+
+            if sig_interface != sig_impl:
+                raise NotImplementedError(
+                    f"Signature mismatch for method '{name}'. "
+                    f"Interface expects {sig_interface}, "
+                    f"but implementation has {sig_impl}."
+                )
+
+        # 2. Extra methods in implementation not in interface
+        for name in implementation_methods:
+            if name not in interface_methods:
+                raise NotImplementedError(
+                    f"Method '{name}' is defined in '{cls.__name__}' "
+                    f"but not declared in interface '{interface.__name__}'."
+                )


### PR DESCRIPTION
This Pull Request resolves Issue #50 by enhancing the behavior of InterfaceProtocolCheckMixin so that it correctly enforces interface–implementation consistency.
Previously, incorrect subclasses could be created without raising any errors because the mixin only compared type hints of existing methods.

Problem

The existing implementation had these missing checks:

It did not raise errors if the interface defined a method that the implementation did not implement.

It did not raise errors if the implementation defined extra methods that were not present in the interface.

It did not properly compare method signatures or parameters, only type-hints of matching keys.

It assumed the first class in MRO after the mixin was always the interface, which is not always dependable.

This caused silent acceptance of incorrect implementations and failed to enforce intended constraints.

Solution

The updated __init_subclass__ method now:

Identifies the correct interface super-class (ignoring the mixin itself).

Gathers all public callable methods from both the interface and implementation.

Ensures that every interface method exists in the implementation.

Ensures that the implementation does not add methods not declared in the interface.

Compares method signatures using inspect.signature to detect mismatches.

Raises clear and descriptive NotImplementedError messages for all of the above cases.

Behavior After Fix

These cases now correctly raise NotImplementedError:

Interface defines method A → implementation missing method A.

Implementation defines method B not declared in interface.

Implementation’s method signature differs from interface signature.

A correct implementation that matches all interface methods and signatures will pass without any error.

Testing

Basic conceptual testing has been done manually:

Stub interface + implementation with missing methods → correctly raises error

Stub interface + implementation with extra methods → correctly raises error

Signature mismatch → correctly raises error

Fully matching interface and implementation → passes

(Test files can be added in a future PR.)

## Summary by Sourcery

Enforce strict interface–implementation conformance in InterfaceProtocolCheckMixin by validating existence and signatures of all public methods.

Bug Fixes:
- Detect and raise errors when an implementation omits methods declared in its interface.
- Detect and raise errors when an implementation defines extra public methods not present in its interface.
- Validate that implementation method signatures exactly match the corresponding interface method signatures instead of only comparing type hints.

Enhancements:
- Determine the correct interface superclass from the implementation’s bases rather than assuming its position in the MRO.