### PR TITLE
fix: resolve failing TestGeolocationAPI test

### DIFF
--- a/xcov19/tests/conftest.py
+++ b/xcov19/tests/conftest.py
@@ -1,10 +1,19 @@
+import os
+
+# Set test env vars BEFORE any app imports to prevent module-level validation failure
+# in xcov19/app/main.py which runs configure_application() at import time.
+os.environ.setdefault("APP_DB_ENGINE_URL", "sqlite+aiosqlite://")
+os.environ.setdefault("APP_ENV", "test")
+
 from collections.abc import Callable
-from typing import List
+from typing import AsyncGenerator, List
 
 from blacksheep.testing import TestClient
 import pytest
 
 from blacksheep import Application
+from xcov19.tests.start_server import start_server
+from xcov19.app.main import app
 from xcov19.dto import (
     AnonymousId,
     GeoLocation,
@@ -131,9 +140,8 @@ def stub_location_srvc() -> LocationQueryServiceInterface:
 
 
 @pytest.fixture(scope="function", name="client")
-async def test_client():
-    # Create a test client
-    async def start_client(app: Application) -> TestClient:
-        return TestClient(app)
-
-    return start_client
+async def test_client() -> AsyncGenerator[TestClient, None]:
+    # Use the real app singleton — all routes are registered via controller_router.
+    # env vars (APP_DB_ENGINE_URL etc.) are set at the top of this file before import.
+    async with start_server(app) as started_app:
+        yield TestClient(started_app)

--- a/xcov19/tests/test_geolocation_api.py
+++ b/xcov19/tests/test_geolocation_api.py
@@ -28,10 +28,11 @@ class TestGeolocationAPI:
             },
         )
 
-        # The current implementation returns ok(), which is null in JSON
-        # response_text = await response.text()
-        # assert response_text.lower() == "resource not found"
-        # Assert the response
-        assert response.content_type() == b"text/plain; charset=utf-8"
-        # assert response.content == b''
+        # ok() returns an empty 200 response with no body and no Content-Type header.
+        # Assert all three to guard against regressions (per Sourcery AI suggestion).
+        # Note: BlackSheep ok() sets no body at all, so response.read() returns None.
+        # Note: BlackSheep headers use bytes keys (HTTP/2 normalized lowercase).
         assert response.status == 200
+        body = await response.read()
+        assert body is None
+        assert b"content-type" not in response.headers


### PR DESCRIPTION
## Summary

Fixes the failing `TestGeolocationAPI::test_location_query_endpoint` test which was broken with `AttributeError: 'function' object has no attribute 'post'`.

## Root Cause

Three separate bugs in `conftest.py` and `test_geolocation_api.py`:

1. **Env vars not set before imports** — `xcov19/app/main.py` calls `configure_application()` at module-level, requiring `APP_DB_ENGINE_URL` to be set *before* any import from that module. Env vars were previously set inside the fixture (too late).

2. **Fixture returned a factory, not a live client** — `test_client` returned the inner `start_client` function instead of a real `TestClient`, causing `.post()` to fail with `AttributeError`.

3. **Wrong `content_type()` assertion** — `ok()` returns an empty 200 response with no Content-Type header, but the test asserted `b'text/plain; charset=utf-8'`.

## Changes

### `xcov19/tests/conftest.py`
- Set `APP_DB_ENGINE_URL` and `APP_ENV` at the **very top** before all imports
- Fixed `test_client` fixture to properly use `start_server(app)` context manager and yield a live `TestClient`

### `xcov19/tests/test_geolocation_api.py`
- Removed incorrect `content_type()` assertion — `ok()` has no body/Content-Type

## Test Results

```
7 passed, 2 warnings in 0.04s ✅
```

Addresses: #39

## Summary by Sourcery

Fix the geolocation API tests by using a live TestClient fixture and aligning assertions with the current endpoint behavior.

Bug Fixes:
- Correct the test_client fixture to yield a real TestClient from the started application instead of a factory function.
- Update the geolocation API test to assert only the HTTP status code, matching the empty 200 response without a Content-Type header.